### PR TITLE
Steam Vent temp should be 500C.

### DIFF
--- a/src/assets/data/geysers.js
+++ b/src/assets/data/geysers.js
@@ -91,7 +91,7 @@ export const geysers = [
   },
   {
     name: 'Steam Vent',
-    temp: { value: 110, unit: 'C' },
+    temp: { value: 500, unit: 'C' },
     maxPressure: { value: 5, unit: 'kg' },
     outputs: [{ name: 'Steam' }],
   },


### PR DESCRIPTION
While using onicalc, adding all my geysers to the tool, I noticed that I couldn't select an accurate representation for my Steam Vents.

For reference: https://oxygennotincluded.gamepedia.com/Steam_Vent