### PR TITLE
Fix Dupe CO2 output

### DIFF
--- a/src/data/dupes.ts
+++ b/src/data/dupes.ts
@@ -9,7 +9,7 @@ export const dupes = {
     },
   ],
   outputs: [
-    { name: 'Carbon Dioxide', value: 20, unit: 'g', rate: 'per second' },
+    { name: 'Carbon Dioxide', value: 2, unit: 'g', rate: 'per second' },
   ],
   traits: [
     {


### PR DESCRIPTION
I was using the web when I noticed an unsual output of CO2 from dupes since they output 2 grams per second, not 20.
![image](https://github.com/user-attachments/assets/dde5938e-9ea5-4e7f-9e2d-58bfddd490d3)
